### PR TITLE
Make leading '1's required

### DIFF
--- a/test/base58check_test.exs
+++ b/test/base58check_test.exs
@@ -55,7 +55,7 @@ defmodule Base58CheckTest do
   end
 
   test "decode58check/1 raises if address too short" do
-    assert_raise ArgumentError, "address of size 1 is too short, expected at least 4", fn ->
+    assert_raise ArgumentError, "address of size 2 is too short, expected 25", fn ->
       decode58check("1e")
     end
   end
@@ -81,6 +81,14 @@ defmodule Base58CheckTest do
   test "decode58check/1 raises on invalid chars in address" do
     assert_raise ArgumentError, fn ->
       decode58check("0J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy")
+    end
+  end
+
+  test "decode58check/1 raises on address with leading `1` dropped" do
+    decode58check("1oNbBopmpvNVLxgDpVe7Lye15LeCBRmXS")
+
+    assert_raise ArgumentError, fn ->
+      decode58check("oNbBopmpvNVLxgDpVe7Lye15LeCBRmXS")
     end
   end
 end


### PR DESCRIPTION
Base58Check requires that leading `<<0>>` bytes are encodes as `'1'`s. Before this PR there was a mechanism which in case of too short decoded byte length prepended the missing` <<0>>` bytes.
It turned out to be a problem for bitcoin address validation. When the leading '1' was dropped (e.g. by user error) from a valid P2PKH address like 1oNbBopmpvNVLxgDpVe7Lye15LeCBRmXS, leading to address oNbBopmpvNVLxgDpVe7Lye15LeCBRmXS the validator would still decode is as valid.
Such address is rejected by bitcoin core.
This PR removes the prefixing mechanism and adds a requirement on leading '1's.